### PR TITLE
Allow single keyword to access a favorite directly

### DIFF
--- a/focus-tab.js
+++ b/focus-tab.js
@@ -14,7 +14,8 @@ function run(args) {
   if (spaceIndex == undefined) {
     Arc.windows[windowIndex].tabs[tabIndex].select();
     Arc.activate();
+  } else {
+    Arc.windows[windowIndex].spaces[spaceIndex].tabs[tabIndex].select();
+    Arc.activate();
   }
-  Arc.windows[windowIndex].spaces[spaceIndex].tabs[tabIndex].select();
-  Arc.activate();
 }

--- a/focus-tab.js
+++ b/focus-tab.js
@@ -13,9 +13,8 @@ function run(args) {
   // console.log("tabIndex:", tabIndex);
   if (spaceIndex == undefined) {
     Arc.windows[windowIndex].tabs[tabIndex].select();
-    Arc.activate();
   } else {
     Arc.windows[windowIndex].spaces[spaceIndex].tabs[tabIndex].select();
-    Arc.activate();
   }
+  Arc.activate();
 }

--- a/list-tabs.js
+++ b/list-tabs.js
@@ -22,7 +22,7 @@ function run(args) {
   // console.log("windownCount: ", windowCount);
 
   ListSpaceTabs(chrome, tabsMap, browser, windowCount, true);
-  ListTopApps(chrome, tabsMap, favorite, true);
+  ListTopApps(chrome, tabsMap, true);
 
   let items = Object.keys(tabsMap).reduce((acc, url) => {
     const domain = getDomain(url);

--- a/list-tabs.js
+++ b/list-tabs.js
@@ -13,26 +13,22 @@ function run(args) {
       ],
     });
   }
-  var excludeLocation = args[0] || "";
 
   let chrome = Application(browser);
+  let favorite = args[0] ? getDomain(args[0]) : null;
   chrome.includeStandardAdditions = true;
   let tabsMap = {};
   let windowCount = chrome.windows.length;
   // console.log("windownCount: ", windowCount);
-  if (excludeLocation == "topApp") {
-    ListTopApps(chrome, tabsMap, false);
-  }
-  else if (excludeLocation == "") {
-    ListSpaceTabs(chrome, tabsMap, browser, windowCount, excludeLocation, true);
-    ListTopApps(chrome, tabsMap, true);
-  }
-  else {
-    ListSpaceTabs(chrome, tabsMap, browser, windowCount, excludeLocation, false);
-  }
+
+  ListSpaceTabs(chrome, tabsMap, browser, windowCount, true);
+  ListTopApps(chrome, tabsMap, favorite, true);
 
   let items = Object.keys(tabsMap).reduce((acc, url) => {
-    acc.push(tabsMap[url]);
+    const domain = getDomain(url);
+    if (favorite === null || (favorite && domain === favorite)) {
+      acc.push(tabsMap[url]);
+    }
     return acc;
   }, []);
 
@@ -48,9 +44,6 @@ function ListTopApps(chrome, tabsMap, ifshowlocation) {
     let matchUrl = url.replace(/(^\w+:|^)\/\//, "");
     let title = tabsTitle[t] || matchUrl;
     let location = tabsLocation[t] || "";
-    if (location != "topApp") {
-      continue;
-    }
     args = `${0},undefined,${t},${url}`;
     // console.log("args: ", args);
     if (ifshowlocation) {
@@ -74,7 +67,7 @@ function ListTopApps(chrome, tabsMap, ifshowlocation) {
   }
 }
 
-function ListSpaceTabs(chrome, tabsMap, browser, windowCount, excludeLocation, ifshowlocation) {
+function ListSpaceTabs(chrome, tabsMap, browser, windowCount, ifshowlocation) {
   let spaceCount = chrome.windows.spaces.length;
   // console.log("spaceCount: ", spaceCount);
 
@@ -95,10 +88,6 @@ function ListSpaceTabs(chrome, tabsMap, browser, windowCount, excludeLocation, i
           let matchUrl = url.replace(/(^\w+:|^)\/\//, "");
           let title = tabsTitle[w][s][t] || matchUrl;
           let location = tabsLocation[w][s][t] || "";
-          // exclude tabs from the current location
-          if (location == excludeLocation) {
-            continue;
-          }
           args = `${0},${s},${t},${url}`;
           // console.log("args: ", args);
           if (ifshowlocation) {
@@ -124,4 +113,9 @@ function ListSpaceTabs(chrome, tabsMap, browser, windowCount, excludeLocation, i
       }
     }
   }
+}
+
+function getDomain(url) {
+  const result = url.match(/^(?:https?:\/\/)?(?:[^@\n]+@)?([^:\/\n?]+)/im);
+  return result[1] ?? null;
 }

--- a/list-tabs.js
+++ b/list-tabs.js
@@ -13,20 +13,27 @@ function run(args) {
       ],
     });
   }
+  var excludeLocation = args[0] || "";
 
   let chrome = Application(browser);
-  let favorite = args[0] ? getDomain(args[0]) : null;
+  let favorite = args[1] ? getDomain(args[1]) : null;
   chrome.includeStandardAdditions = true;
   let tabsMap = {};
   let windowCount = chrome.windows.length;
   // console.log("windownCount: ", windowCount);
-
-  ListSpaceTabs(chrome, tabsMap, browser, windowCount, true);
-  ListTopApps(chrome, tabsMap, true);
+  if (excludeLocation == "topApp") {
+    ListTopApps(chrome, tabsMap, false);
+  }
+  else if (excludeLocation == "") {
+    ListSpaceTabs(chrome, tabsMap, browser, windowCount, excludeLocation, true);
+    ListTopApps(chrome, tabsMap, true);
+  }
+  else {
+    ListSpaceTabs(chrome, tabsMap, browser, windowCount, excludeLocation, false);
+  }
 
   let items = Object.keys(tabsMap).reduce((acc, url) => {
-    const domain = getDomain(url);
-    if (favorite === null || (favorite && domain === favorite)) {
+    if (favorite === null || getDomain(url) === favorite) {
       acc.push(tabsMap[url]);
     }
     return acc;
@@ -44,6 +51,9 @@ function ListTopApps(chrome, tabsMap, ifshowlocation) {
     let matchUrl = url.replace(/(^\w+:|^)\/\//, "");
     let title = tabsTitle[t] || matchUrl;
     let location = tabsLocation[t] || "";
+    if (location != "topApp") {
+      continue;
+    }
     args = `${0},undefined,${t},${url}`;
     // console.log("args: ", args);
     if (ifshowlocation) {
@@ -67,7 +77,7 @@ function ListTopApps(chrome, tabsMap, ifshowlocation) {
   }
 }
 
-function ListSpaceTabs(chrome, tabsMap, browser, windowCount, ifshowlocation) {
+function ListSpaceTabs(chrome, tabsMap, browser, windowCount, excludeLocation, ifshowlocation) {
   let spaceCount = chrome.windows.spaces.length;
   // console.log("spaceCount: ", spaceCount);
 
@@ -88,6 +98,10 @@ function ListSpaceTabs(chrome, tabsMap, browser, windowCount, ifshowlocation) {
           let matchUrl = url.replace(/(^\w+:|^)\/\//, "");
           let title = tabsTitle[w][s][t] || matchUrl;
           let location = tabsLocation[w][s][t] || "";
+          // exclude tabs from the current location
+          if (location == excludeLocation) {
+            continue;
+          }
           args = `${0},${s},${t},${url}`;
           // console.log("args: ", args);
           if (ifshowlocation) {


### PR DESCRIPTION
In [issue 12](https://github.com/QIanGua/Alfred-Workflow-for-Arc/issues/12), there's a request for "have an Alfred command to take us directly to a favourite." This patch allows that. Usage:
1. Copy the "atabs" script filter.
2. Change its keyword to whatever you want your single keyword to be (e.g. I used "gcal" for my Google Calendar favorite).
3. Change its Placeholder Title if you want (not really necessary, as this gets replaced quickly by the search result).
4. In the "script" field after `./list-tabs.js`, add a space, then 'topApp', and then the URL of the favorite you want. Note that the logic just looks at the favorite's *domain*, because the specific URLs of the most common favorites, like Gmail or Google Calendar, are very changeable — I figured that only the domain is consistent. For example:
`./list-tabs.js topApp https://calendar.google.com/calendar/u/0/r/week`
5. Connect your new script filter to the same Args and Vars filter that the "atabs" one connects to.

For example, here's my setup with Google Calendar and GMail script filters:
<img width="877" alt="image" src="https://github.com/user-attachments/assets/1d760edd-6215-40b3-8f42-9e5a5b71ae9f">
 
Now you should be able to simply enter, for example, "gcal" and see only your Google Calendar suggested.

~Note that this approach removes the unused excludeLocations argument in favor of a specific favorite domain.~ Leaves excludeLocations alone! (I now understand that it is used, and how 😄 )